### PR TITLE
Update clone_libfranka.sh - fix libfranka incompatibly issues.

### DIFF
--- a/bash_scripts/clone_libfranka.sh
+++ b/bash_scripts/clone_libfranka.sh
@@ -12,7 +12,7 @@ case $firmware_version in
   commit=f1f46fb
   ;;
 5)
-  commit=c452ba2
+  commit=83e931c
   ;;
 6)
   commit=4f9e3cc


### PR DESCRIPTION
Replace libfranka 0.9.0 by 0.9.1. Libfranka >= 0.9.1 < 0.10.0 is compatible version to robot system >= 4.2.1. https://frankaemika.github.io/docs/compatibility.html